### PR TITLE
ref:FR:NAF, ref:FR:SIREN and ref:FR:SIRET

### DIFF
--- a/keys.txt
+++ b/keys.txt
@@ -125,7 +125,11 @@ ref		// without extra clasification like ref:xxx, it is most likely shop related
 ref:vatin
 designation	// used to record the legal classification of an object, quick check show mostly shop-type related.  https://wiki.openstreetmap.org/wiki/Key:designation
 SEP:CLAVEESC    // from amenity-kindergarten.json - undocumented, seems to be subtype of facility code?
-identifier          // undocumented, seems office=related
+identifier      // undocumented, seems office=related
+ref:FR:SIRET    // organisation number given by INSEE in France https://wiki.openstreetmap.org/wiki/Key:ref:FR:SIRET
+ref:FR:SIREN    // company number given by INSEE in France https://wiki.openstreetmap.org/wiki/Key:ref:FR:SIREN
+ref:FR:NAF      // 5-digits code describing organization main activity in France https://wiki.openstreetmap.org/wiki/Key:ref:FR:NAF
+
 
 // contacts
 contact_person
@@ -864,3 +868,41 @@ drinking_water_available    // fake, used by highway=rest_area, tourism=wilderne
 
 
 ### TODO ###
+
+// from _find_popular_subkeys.json
+cooperative
+allotments
+atv
+electronics
+piercing
+political_party
+fan
+
+// from club.json
+plots
+local_food
+monitoring:pedestrian
+recording:automated
+check_out
+check_in
+manufacturer
+
+// from healthcare.json
+latitude
+longitude
+COVID_BED
+COVID_ICU
+COVID_TEST
+HF_ID
+HF_TYPE
+RoadConn
+entrance:ramp
+HF_N_EN
+bin
+Comments
+
+// from shop.json
+fixme:atp
+changing_table:adult
+Commercial
+status

--- a/sc_to_remove.txt
+++ b/sc_to_remove.txt
@@ -21,7 +21,9 @@ private val KEYS_THAT_SHOULD_BE_REMOVED_WHEN_PLACE_IS_REPLACED = listOf(
     // names and identifications
     "name_?[1-9]?(:.*)?", ".*_name_?[1-9]?(:.*)?", "noname", "branch(:.*)?", "brand(:.*)?",
     "not:brand(:.*)?", "network(:wikidata)?", "operator(:.*)?", "operator_type", "ref",
-    "ref:vatin", "designation", "SEP:CLAVEESC", "identifier",
+    "ref:vatin", "designation", "SEP:CLAVEESC", "identifier", "ref:FR:SIRET", "ref:FR:SIREN",
+    "ref:FR:NAF",
+   
     // contacts
     "contact_person", "contact(:.*)?", "phone(:.*)?", "phone_?[1-9]?", "emergency:phone",
     "emergency_telephone_code",


### PR DESCRIPTION
Add support for ref:FR:NAF, ref:FR:SIREN and ref:FR:SIRET used in France.
Related to https://github.com/streetcomplete/StreetComplete/pull/5917